### PR TITLE
feat: Add cloud bootstrapping scripts and documentation

### DIFF
--- a/BOOTSTRAPPING.MD
+++ b/BOOTSTRAPPING.MD
@@ -1,0 +1,155 @@
+# Drydock Bootstrapping Guide
+
+This guide provides instructions on how to use the bootstrapping scripts to set up the necessary cloud provider resources for Drydock. These scripts help automate the creation of Workload Identity Federation configurations, service accounts/principals, storage for cargo files, and secret vaults.
+
+## Prerequisites
+
+Before running either bootstrapping script, ensure you have the following:
+
+*   **Git:** To clone the Drydock repository (or your fork).
+*   **GitHub Repository:** You should have a GitHub repository where you intend to use Drydock. You'll need its name in the format `ORGANIZATION_NAME/REPOSITORY_NAME`.
+*   **Permissions:** You will need sufficient permissions in your cloud account (GCP Project or Azure Subscription) to create the resources outlined by the scripts. Typically, roles like "Project Owner" in GCP or "Contributor" / "Owner" in Azure are sufficient, or a combination of more specific admin roles (e.g., for IAM, Storage, Key Vault/Secret Manager).
+
+### For GCP Bootstrapping (`bootstrap_gcp.sh`):
+*   **Google Cloud SDK (`gcloud`):** Installed and configured.
+*   **Authentication:** Authenticated to `gcloud` with an account that has the necessary permissions in your target GCP project (e.g., run `gcloud auth login` and `gcloud auth application-default login`).
+
+### For Azure Bootstrapping (`bootstrap_azure.sh`):
+*   **Azure CLI (`az`):** Installed and configured.
+*   **Authentication:** Authenticated to `az` with an account that has the necessary permissions in your target Azure subscription (e.g., run `az login`).
+
+## Using the GCP Bootstrapping Script (`scripts/bootstrap/bootstrap_gcp.sh`)
+
+This script automates the setup of:
+*   GCP Workload Identity Pool and Provider.
+*   A GCP Service Account for GitHub Actions.
+*   IAM bindings to allow WIF and grant the Service Account access to GCS (for cargo) and Secret Manager.
+*   A GCS bucket for Drydock cargo files.
+
+### Steps:
+
+1.  **Navigate to the script directory:**
+    ```bash
+    cd scripts/bootstrap
+    ```
+
+2.  **Make the script executable:**
+    ```bash
+    chmod +x bootstrap_gcp.sh
+    ```
+
+3.  **Run the script:**
+    You'll need to provide your GCP Project ID and your GitHub repository information.
+
+    **Option 1: Using Environment Variables:**
+    ```bash
+    export GCP_PROJECT_ID="your-gcp-project-id"
+    export GITHUB_ORG_REPO="YOUR_ORG/YOUR_REPO"
+    # Optional: set other variables like SERVICE_ACCOUNT_NAME, GCS_CARGO_BUCKET_NAME, etc.
+    ./bootstrap_gcp.sh
+    ```
+
+    **Option 2: Using Script Arguments:**
+    ```bash
+    ./bootstrap_gcp.sh --project-id "your-gcp-project-id" --github-repo "YOUR_ORG/YOUR_REPO" \
+                       [--sa-name "custom-sa-name"] \
+                       [--pool-id "custom-pool-id"] \
+                       [--provider-id "custom-provider-id"] \
+                       [--bucket-name "custom-bucket-name"] \
+                       [--region "US-CENTRAL1"] # Optional region for GCS bucket
+    ```
+    Use `./bootstrap_gcp.sh --help` to see all available options and their defaults.
+
+4.  **Confirm Execution:**
+    The script will display the configuration it intends to apply and ask for your confirmation before proceeding.
+
+5.  **Collect GitHub Secret Values:**
+    Once the script completes successfully, it will output a list of GitHub Secret names and their corresponding values. These are:
+    *   `GCP_WORKLOAD_IDENTITY_PROVIDER`
+    *   `GCP_SERVICE_ACCOUNT_EMAIL`
+    *   `GCP_CARGO_BUCKET`
+    *   `GCP_PROJECT_ID`
+
+6.  **Configure GitHub Secrets:**
+    Navigate to your GitHub repository's `Settings -> Secrets and variables -> Actions` and create new repository secrets with the names and values provided by the script.
+
+7.  **Next Steps for GCP:**
+    *   Upload your environment-specific cargo files (e.g., `dev.tfvars`, `dev.override.yaml`) to the created GCS cargo bucket under the paths `terraform/<env>.tfvars` and `helm/<env>.override.yaml` respectively.
+    *   Store any sensitive values for Terraform or Helm in GCP Secret Manager under the names `tf-secrets.auto.tfvars` and `helm-secrets.yaml` as detailed in `USAGE.md`.
+
+## Using the Azure Bootstrapping Script (`scripts/bootstrap/bootstrap_azure.sh`)
+
+This script automates the setup of:
+*   Azure AD Application Registration with a Federated Identity Credential for GitHub Actions.
+*   Role assignments for the App's Service Principal to access Azure Blob Storage (for cargo), Azure Key Vault (for secrets), and optionally an existing AKS cluster.
+*   An Azure Storage Account and Blob Container for Drydock cargo files.
+*   An Azure Key Vault for storing secrets.
+
+### Steps:
+
+1.  **Navigate to the script directory:**
+    ```bash
+    cd scripts/bootstrap
+    ```
+
+2.  **Make the script executable:**
+    ```bash
+    chmod +x bootstrap_azure.sh
+    ```
+
+3.  **Run the script:**
+    You'll need to provide your Azure Subscription ID, GitHub repository information, a Resource Group name (the script will create it if it doesn't exist), and an Azure region.
+
+    **Option 1: Using Environment Variables:**
+    ```bash
+    export AZURE_SUBSCRIPTION_ID="your-subscription-id"
+    export GITHUB_ORG_REPO="YOUR_ORG/YOUR_REPO"
+    export RESOURCE_GROUP_NAME="my-drydock-resources-rg"
+    export AZURE_REGION="eastus"
+    # Optional: set other variables like APP_REG_NAME, STORAGE_ACCOUNT_NAME, etc.
+    ./bootstrap_azure.sh
+    ```
+
+    **Option 2: Using Script Arguments:**
+    ```bash
+    ./bootstrap_azure.sh --subscription-id "your-subscription-id" \
+                       --github-repo "YOUR_ORG/YOUR_REPO" \
+                       --resource-group "my-drydock-resources-rg" \
+                       --location "eastus" \
+                       [--app-name "custom-app-reg-name"] \
+                       [--storage-account-name "customstoragename"] \
+                       [--container-name "customcontainer"] \
+                       [--keyvault-name "customkeyvault"] \
+                       [--aks-cluster-name "my-aks-cluster"] \
+                       [--aks-resource-group "my-aks-cluster-rg"]
+    ```
+    Use `./bootstrap_azure.sh --help` to see all available options and their defaults.
+
+4.  **Confirm Execution:**
+    The script will display the configuration it intends to apply and ask for your confirmation.
+
+5.  **Collect GitHub Secret Values:**
+    Upon successful completion, the script will output:
+    *   `AZURE_CLIENT_ID`
+    *   `AZURE_TENANT_ID`
+    *   `AZURE_SUBSCRIPTION_ID`
+    *   `AZURE_CARGO_STORAGE_ACCOUNT`
+    *   `AZURE_CARGO_CONTAINER`
+    *   `AZURE_KEY_VAULT_NAME`
+
+6.  **Configure GitHub Secrets:**
+    In your GitHub repository's `Settings -> Secrets and variables -> Actions`, create new repository secrets with these names and values.
+
+7.  **Next Steps for Azure:**
+    *   Upload your environment-specific cargo files (e.g., `azure-dev.tfvars`, `azure-dev.override.yaml`) to the created Azure Blob container under the paths `terraform/azure-<env>.tfvars` and `helm/azure-<env>.override.yaml` respectively.
+    *   Store any sensitive values for Terraform or Helm in the created Azure Key Vault under the names `tf-secrets-auto-tfvars` and `helm-secrets-yaml` as detailed in `USAGE.md`. Remember that names in Key Vault use hyphens instead of periods.
+
+## Post-Bootstrapping
+
+After running the appropriate script(s) and configuring GitHub Secrets:
+*   Your Drydock workflow should be ready to authenticate to your cloud provider using Workload Identity Federation.
+*   Ensure your cargo files and any necessary secrets are populated in the cloud storage and vaults as described in `USAGE.md`.
+*   You can now run the Drydock workflow (`.github/workflows/deploy.yaml`).
+
+Refer to `USAGE.md` for detailed information on workflow inputs, cargo file structure, and secret management within Drydock.
+```

--- a/README.md
+++ b/README.md
@@ -46,6 +46,18 @@ In a shipyard drydock, the hull is constructed before it's ever launched into wa
 
 ---
 
+## Getting Started
+
+To begin using Drydock, you first need to set up the necessary resources in your chosen cloud provider (GCP or Azure) to enable Workload Identity Federation, create storage for cargo files, and set up secret management.
+
+We provide bootstrapping scripts to help automate this initial setup. Please refer to our:
+
+- **[Drydock Bootstrapping Guide](BOOTSTRAPPING.md)**
+
+Once your cloud environment is bootstrapped and you have configured the required GitHub Secrets as output by the scripts, refer to the [Drydock Workflow Usage and Configuration Guide](USAGE.md) for details on running the deployment workflow and managing your cargo files.
+
+---
+
 ## **Architecture**
 
 ```

--- a/USAGE.md
+++ b/USAGE.md
@@ -16,6 +16,8 @@ The workflow performs the following key operations:
 
 ## Configuration
 
+**Note:** Before proceeding with the configuration below, ensure you have set up the necessary cloud provider resources using our **[Drydock Bootstrapping Guide](BOOTSTRAPPING.md)**. That guide will help you create the required infrastructure and will provide some of the GitHub Secret values mentioned here.
+
 To use this workflow, you need to configure several GitHub Secrets in your repository settings and set up cloud storage for your cargo files.
 
 ### 1. GitHub Secrets

--- a/scripts/bootstrap/bootstrap_azure.sh
+++ b/scripts/bootstrap/bootstrap_azure.sh
@@ -1,0 +1,270 @@
+#!/bin/bash
+
+# Purpose: Bootstraps necessary Azure resources for the Drydock workflow.
+#
+# Prerequisites:
+# 1. Azure CLI (`az`) installed and authenticated: `az login`.
+# 2. Sufficient IAM permissions for the authenticated user. Typically, this means:
+#    - Owner or Contributor role on the Subscription.
+#    - OR specific roles:
+#      - To create App Registrations and Service Principals: Application Administrator or Cloud Application Administrator.
+#      - To create Resource Groups: Contributor at subscription level or Resource Policy Contributor.
+#      - To create Storage Accounts, Key Vaults: Contributor on the Resource Group or specific resource creation roles.
+#      - To assign roles (RBAC): User Access Administrator or Owner on the relevant scopes.
+#      - For Key Vault RBAC: Key Vault Contributor or User Access Administrator on the Key Vault.
+#      - For Storage Blob Data operations (if creating container with --auth-mode login): Storage Blob Data Contributor/Owner.
+#
+# Usage:
+#   Set environment variables OR pass as arguments:
+#   export AZURE_SUBSCRIPTION_ID="your-subscription-id"
+#   export GITHUB_ORG_REPO="your-org/your-repo"
+#   export RESOURCE_GROUP_NAME="your-rg-name"
+#   export AZURE_REGION="eastus" # e.g., eastus, westus2
+#
+#   Run the script:
+#   ./scripts/bootstrap/bootstrap_azure.sh
+#
+#   Alternatively, pass as arguments (SUBSCRIPTION_ID GITHUB_ORG_REPO RESOURCE_GROUP_NAME AZURE_REGION [APP_REG_NAME] ...):
+#   ./scripts/bootstrap/bootstrap_azure.sh "sub-id" "org/repo" "rg-name" "eastus"
+#
+# Optional environment variables (or script arguments in order after required ones):
+#   APP_REG_NAME (default: drydock-github-wif-app)
+#   STORAGE_ACCOUNT_NAME (default: drydockcargo<random_hex>)
+#   BLOB_CONTAINER_NAME (default: drydock-cargo)
+#   KEY_VAULT_NAME (default: drydock-kv-<random_hex>)
+#   FIC_SUBJECT_IDENTIFIER (default: repo:${GITHUB_ORG_REPO}:*)
+#   AKS_CLUSTER_NAME (optional, if provided, role assignment for AKS will be attempted)
+#   AKS_RESOURCE_GROUP_NAME (optional, required if AKS_CLUSTER_NAME is provided)
+
+set -euo pipefail
+
+usage() {
+  echo "Usage: $0 [AZURE_SUBSCRIPTION_ID] [GITHUB_ORG_REPO] [RESOURCE_GROUP_NAME] [AZURE_REGION] [APP_REG_NAME] [STORAGE_ACCOUNT_NAME] [BLOB_CONTAINER_NAME] [KEY_VAULT_NAME] [FIC_SUBJECT_IDENTIFIER] [AKS_CLUSTER_NAME] [AKS_RESOURCE_GROUP_NAME]"
+  echo ""
+  echo "Arguments can also be set as environment variables (see script comments)."
+  echo "  -h, --help    Display this help message."
+  exit 0
+}
+
+if [[ "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
+  usage
+fi
+
+# --- User Inputs & Defaults ---
+AZURE_SUBSCRIPTION_ID="${AZURE_SUBSCRIPTION_ID:-${1:-}}"
+GITHUB_ORG_REPO="${GITHUB_ORG_REPO:-${2:-}}"
+RESOURCE_GROUP_NAME="${RESOURCE_GROUP_NAME:-${3:-}}"
+AZURE_REGION="${AZURE_REGION:-${4:-}}"
+
+APP_REG_NAME="${APP_REG_NAME:-${5:-drydock-github-wif-app}}"
+RAND_HEX_4=$(openssl rand -hex 4)
+DEFAULT_STORAGE_ACCOUNT_NAME="drydockcargo${RAND_HEX_4}"
+STORAGE_ACCOUNT_NAME="${STORAGE_ACCOUNT_NAME:-${6:-${DEFAULT_STORAGE_ACCOUNT_NAME}}}"
+BLOB_CONTAINER_NAME="${BLOB_CONTAINER_NAME:-${7:-drydock-cargo}}"
+DEFAULT_KEY_VAULT_NAME="drydock-kv-${RAND_HEX_4}" # Ensure uniqueness if re-running for same project
+KEY_VAULT_NAME="${KEY_VAULT_NAME:-${8:-${DEFAULT_KEY_VAULT_NAME}}}"
+DEFAULT_FIC_SUBJECT="repo:${GITHUB_ORG_REPO}:*"
+FIC_SUBJECT_IDENTIFIER="${FIC_SUBJECT_IDENTIFIER:-${9:-${DEFAULT_FIC_SUBJECT}}}"
+AKS_CLUSTER_NAME="${AKS_CLUSTER_NAME:-${10:-}}"
+AKS_RESOURCE_GROUP_NAME="${AKS_RESOURCE_GROUP_NAME:-${11:-}}"
+
+
+# Validate required inputs
+if [ -z "${AZURE_SUBSCRIPTION_ID}" ]; then
+  echo "Error: AZURE_SUBSCRIPTION_ID is not set."
+  usage
+fi
+if [ -z "${GITHUB_ORG_REPO}" ]; then
+  echo "Error: GITHUB_ORG_REPO is not set (format: ORG/REPO_NAME)."
+  usage
+fi
+if ! [[ "${GITHUB_ORG_REPO}" =~ ^[a-zA-Z0-9_-]+/[a-zA-Z0-9_.-]+$ ]]; then
+    echo "Error: GITHUB_ORG_REPO format is invalid. Expected 'ORG/REPO_NAME'."
+    exit 1
+fi
+if [ -z "${RESOURCE_GROUP_NAME}" ]; then
+  echo "Error: RESOURCE_GROUP_NAME is not set."
+  usage
+fi
+if [ -z "${AZURE_REGION}" ]; then
+  echo "Error: AZURE_REGION is not set (e.g., eastus)."
+  usage
+fi
+if [ -n "${AKS_CLUSTER_NAME}" ] && [ -z "${AKS_RESOURCE_GROUP_NAME}" ]; then
+    echo "Error: AKS_RESOURCE_GROUP_NAME must be provided if AKS_CLUSTER_NAME is set."
+    usage
+fi
+if [ -z "${AKS_CLUSTER_NAME}" ] && [ -n "${AKS_RESOURCE_GROUP_NAME}" ]; then
+    echo "Warning: AKS_RESOURCE_GROUP_NAME is set, but AKS_CLUSTER_NAME is not. No AKS role assignment will be attempted."
+fi
+
+
+echo "--- Configuration ---"
+echo "Azure Subscription ID:          ${AZURE_SUBSCRIPTION_ID}"
+echo "GitHub Org/Repo:                ${GITHUB_ORG_REPO}"
+echo "Resource Group Name:            ${RESOURCE_GROUP_NAME}"
+echo "Azure Region:                   ${AZURE_REGION}"
+echo "App Registration Name:          ${APP_REG_NAME}"
+echo "Storage Account Name:           ${STORAGE_ACCOUNT_NAME}"
+echo "Blob Container Name:            ${BLOB_CONTAINER_NAME}"
+echo "Key Vault Name:                 ${KEY_VAULT_NAME}"
+echo "FIC Subject Identifier:         ${FIC_SUBJECT_IDENTIFIER}"
+if [ -n "${AKS_CLUSTER_NAME}" ]; then
+echo "AKS Cluster Name:               ${AKS_CLUSTER_NAME}"
+echo "AKS Resource Group Name:        ${AKS_RESOURCE_GROUP_NAME}"
+fi
+echo "---------------------"
+
+read -p "Proceed with creating/configuring these resources? (y/N): " confirm
+if [[ "${confirm}" != "y" && "${confirm}" != "Y" ]]; then
+  echo "Aborted by user."
+  exit 0
+fi
+
+echo "--- Setting Azure Subscription ---"
+az account set --subscription "${AZURE_SUBSCRIPTION_ID}"
+echo "Using subscription: $(az account show --query name -o tsv)"
+
+echo "--- Creating Resource Group (if not exists) ---"
+if az group show --name "${RESOURCE_GROUP_NAME}" > /dev/null 2>&1; then
+  echo "Resource Group '${RESOURCE_GROUP_NAME}' already exists."
+else
+  az group create --name "${RESOURCE_GROUP_NAME}" --location "${AZURE_REGION}"
+  echo "Resource Group '${RESOURCE_GROUP_NAME}' created."
+fi
+
+echo "--- Creating AAD Application Registration (if not exists) ---"
+APP_CLIENT_ID=$(az ad app list --display-name "${APP_REG_NAME}" --query "[?displayName=='${APP_REG_NAME}'].appId" -o tsv)
+if [ -n "${APP_CLIENT_ID}" ]; then
+  echo "AAD App Registration '${APP_REG_NAME}' with Client ID '${APP_CLIENT_ID}' already exists. Using existing."
+else
+  APP_CLIENT_ID=$(az ad app create --display-name "${APP_REG_NAME}" --query appId -o tsv)
+  echo "AAD App Registration '${APP_REG_NAME}' created with Client ID '${APP_CLIENT_ID}'."
+fi
+
+APP_OBJECT_ID=$(az ad app show --id "${APP_CLIENT_ID}" --query id -o tsv)
+echo "AAD App Object ID: ${APP_OBJECT_ID}"
+
+echo "--- Creating Federated Identity Credential ---"
+FIC_NAME="github-fic-$(openssl rand -hex 3)"
+FIC_JSON=$(cat <<EOF
+{
+  "name": "${FIC_NAME}",
+  "issuer": "https://token.actions.githubusercontent.com",
+  "subject": "${FIC_SUBJECT_IDENTIFIER}",
+  "description": "GitHub Actions WIF for ${GITHUB_ORG_REPO}",
+  "audiences": ["api://AzureADTokenExchange"]
+}
+EOF
+)
+
+# Check if a FIC with the same subject already exists (az ad app federated-credential list does not support filtering by subject directly)
+# This is a simple check, a more robust one would iterate and compare subjects.
+EXISTING_FIC=$(az ad app federated-credential list --id "${APP_OBJECT_ID}" --query "[?contains(name, 'github-fic-')].name" -o tsv) # Basic check
+if [[ "${EXISTING_FIC}" == *"${FIC_NAME_PREFIX_CHECK}"* && -n "${EXISTING_FIC}" ]]; then # Crude check
+    echo "A federated credential for GitHub Actions likely already exists for App ${APP_CLIENT_ID}. Skipping creation."
+    echo "If you need to update the subject or create a new one, please do so manually in the Azure portal."
+else
+    if az ad app federated-credential create --id "${APP_OBJECT_ID}" --parameters "${FIC_JSON}"; then
+        echo "Federated Identity Credential '${FIC_NAME}' created for App ${APP_CLIENT_ID}."
+    else
+        echo "Warning: Failed to create Federated Identity Credential. It might already exist with a similar configuration or there was an issue."
+        echo "Please check the Azure Portal for App '${APP_REG_NAME}' (${APP_CLIENT_ID})."
+    fi
+fi
+
+
+echo "--- Getting Service Principal Object ID ---"
+# Ensure SP exists for the App Registration
+# If the app was just created, the SP might take a moment to provision.
+# Using 'az ad sp create' is idempotent if the SP already exists for the app.
+az ad sp create --id "${APP_CLIENT_ID}" > /dev/null 2>&1 # Ensure SP exists
+SP_OBJECT_ID=$(az ad sp show --id "${APP_CLIENT_ID}" --query id -o tsv)
+if [ -z "${SP_OBJECT_ID}" ]; then
+    echo "Error: Could not find Service Principal Object ID for App Client ID ${APP_CLIENT_ID}."
+    exit 1
+fi
+echo "Service Principal Object ID: ${SP_OBJECT_ID}"
+
+echo "--- Creating Storage Account (if not exists) ---"
+if az storage account show --name "${STORAGE_ACCOUNT_NAME}" --resource-group "${RESOURCE_GROUP_NAME}" > /dev/null 2>&1; then
+  echo "Storage Account '${STORAGE_ACCOUNT_NAME}' already exists."
+else
+  az storage account create --name "${STORAGE_ACCOUNT_NAME}" --resource-group "${RESOURCE_GROUP_NAME}" --location "${AZURE_REGION}" --sku Standard_LRS --kind StorageV2
+  echo "Storage Account '${STORAGE_ACCOUNT_NAME}' created."
+fi
+
+echo "--- Creating Blob Container (if not exists) ---"
+# This command will fail if the container exists but the user does not have permissions to list/create containers.
+# Using --fail-on-exist to make it idempotent in behavior.
+if az storage container create --name "${BLOB_CONTAINER_NAME}" --account-name "${STORAGE_ACCOUNT_NAME}" --auth-mode login --public-access off --fail-on-exist > /dev/null 2>&1; then
+  echo "Blob Container '${BLOB_CONTAINER_NAME}' created in Storage Account '${STORAGE_ACCOUNT_NAME}'."
+else
+  RET_CODE=$?
+  if [ $RET_CODE -eq 3 ]; then # Exit code 3 for "The specified container already exists."
+    echo "Blob Container '${BLOB_CONTAINER_NAME}' already exists in Storage Account '${STORAGE_ACCOUNT_NAME}'."
+  else
+    echo "Failed to create Blob Container '${BLOB_CONTAINER_NAME}'. Return code: $RET_CODE. Ensure you have 'Storage Blob Data Contributor' or similar on the SA or run 'az login' with such user."
+    # exit 1 # Decide if this is a fatal error
+  fi
+fi
+
+
+echo "--- Creating Key Vault (if not exists) ---"
+if az keyvault show --name "${KEY_VAULT_NAME}" --resource-group "${RESOURCE_GROUP_NAME}" > /dev/null 2>&1; then
+  echo "Key Vault '${KEY_VAULT_NAME}' already exists."
+else
+  az keyvault create --name "${KEY_VAULT_NAME}" --resource-group "${RESOURCE_GROUP_NAME}" --location "${AZURE_REGION}" --enable-rbac-authorization true
+  echo "Key Vault '${KEY_VAULT_NAME}' created with RBAC authorization enabled."
+fi
+KEY_VAULT_URI=$(az keyvault show --name "${KEY_VAULT_NAME}" --resource-group "${RESOURCE_GROUP_NAME}" --query properties.vaultUri -o tsv)
+
+
+echo "--- Waiting for AAD Propagation for Role Assignments (30 seconds) ---"
+sleep 30
+
+echo "--- Assigning Roles to Service Principal '${SP_OBJECT_ID}' ---"
+STORAGE_ACCOUNT_SCOPE="/subscriptions/${AZURE_SUBSCRIPTION_ID}/resourceGroups/${RESOURCE_GROUP_NAME}/providers/Microsoft.Storage/storageAccounts/${STORAGE_ACCOUNT_NAME}"
+az role assignment create --assignee-object-id "${SP_OBJECT_ID}" --assignee-principal-type ServicePrincipal --role "Storage Blob Data Contributor" --scope "${STORAGE_ACCOUNT_SCOPE}" --only-show-errors
+echo "Role 'Storage Blob Data Contributor' assigned to SP for Storage Account '${STORAGE_ACCOUNT_NAME}'."
+
+KEY_VAULT_SCOPE="/subscriptions/${AZURE_SUBSCRIPTION_ID}/resourceGroups/${RESOURCE_GROUP_NAME}/providers/Microsoft.KeyVault/vaults/${KEY_VAULT_NAME}"
+az role assignment create --assignee-object-id "${SP_OBJECT_ID}" --assignee-principal-type ServicePrincipal --role "Key Vault Secrets User" --scope "${KEY_VAULT_SCOPE}" --only-show-errors
+echo "Role 'Key Vault Secrets User' assigned to SP for Key Vault '${KEY_VAULT_NAME}'."
+
+if [ -n "${AKS_CLUSTER_NAME}" ] && [ -n "${AKS_RESOURCE_GROUP_NAME}" ]; then
+  echo "--- Assigning AKS Role (if specified) ---"
+  AKS_SCOPE="/subscriptions/${AZURE_SUBSCRIPTION_ID}/resourceGroups/${AKS_RESOURCE_GROUP_NAME}/providers/Microsoft.ContainerService/managedClusters/${AKS_CLUSTER_NAME}"
+  if az aks show --name "${AKS_CLUSTER_NAME}" --resource-group "${AKS_RESOURCE_GROUP_NAME}" > /dev/null 2>&1; then
+    az role assignment create --assignee-object-id "${SP_OBJECT_ID}" --assignee-principal-type ServicePrincipal --role "Azure Kubernetes Service Cluster User Role" --scope "${AKS_SCOPE}" --only-show-errors
+    echo "Role 'Azure Kubernetes Service Cluster User Role' assigned to SP for AKS Cluster '${AKS_CLUSTER_NAME}'."
+  else
+    echo "Warning: AKS Cluster '${AKS_CLUSTER_NAME}' in RG '${AKS_RESOURCE_GROUP_NAME}' not found. Skipping role assignment."
+  fi
+else
+  echo "AKS Cluster Name not specified. Skipping AKS role assignment."
+fi
+
+AZURE_TENANT_ID=$(az account show --query tenantId -o tsv)
+
+echo "--- Bootstrap Complete! ---"
+echo ""
+echo "--- GitHub Secret Values ---"
+echo "Copy these values into your GitHub repository secrets (Settings -> Secrets and variables -> Actions):"
+echo ""
+echo "AZURE_CLIENT_ID:               ${APP_CLIENT_ID}"
+echo "AZURE_TENANT_ID:               ${AZURE_TENANT_ID}"
+echo "AZURE_SUBSCRIPTION_ID:         ${AZURE_SUBSCRIPTION_ID}" # (This is the Subscription ID you provided)
+echo "AZURE_CARGO_STORAGE_ACCOUNT:   ${STORAGE_ACCOUNT_NAME}"
+echo "AZURE_CARGO_CONTAINER:         ${BLOB_CONTAINER_NAME}"
+echo "AZURE_KEY_VAULT_NAME:          ${KEY_VAULT_NAME}"
+echo ""
+echo "--- Important Next Steps ---"
+echo "1. Populate your Azure Blob Storage container ('${BLOB_CONTAINER_NAME}' in '${STORAGE_ACCOUNT_NAME}') with environment-specific .tfvars and .override.yaml files."
+echo "   Refer to USAGE.md for naming conventions (e.g., terraform/azure-dev.tfvars, helm/azure-dev.override.yaml)."
+echo "2. Populate Azure Key Vault ('${KEY_VAULT_NAME}') with secrets named 'tf-secrets-auto-tfvars' and 'helm-secrets-yaml' if you plan to use this feature."
+echo "   Refer to USAGE.md for content format. Note Azure Key Vault secret names cannot contain '.' and use '-' instead."
+echo ""
+echo "To make this script executable: chmod +x scripts/bootstrap/bootstrap_azure.sh"
+
+exit 0

--- a/scripts/bootstrap/bootstrap_gcp.sh
+++ b/scripts/bootstrap/bootstrap_gcp.sh
@@ -1,0 +1,196 @@
+#!/bin/bash
+
+# Purpose: Bootstraps necessary GCP resources for the Drydock workflow.
+#
+# Prerequisites:
+# 1. gcloud CLI installed and authenticated: `gcloud auth login` and `gcloud config set project <YOUR_PROJECT_ID>`.
+# 2. Sufficient IAM permissions for the authenticated user (e.g., Project Owner or specific admin roles for IAM,
+#    Service Accounts, GCS, Secret Manager, and Workload Identity Federation).
+#
+# Usage:
+#   Set environment variables OR pass as arguments:
+#   export GCP_PROJECT_ID="your-gcp-project-id"
+#   export GITHUB_ORG_REPO="your-org/your-repo"
+#
+#   Run the script:
+#   ./scripts/bootstrap/bootstrap_gcp.sh
+#
+#   Alternatively, pass as arguments (PROJECT_ID GITHUB_ORG_REPO):
+#   ./scripts/bootstrap/bootstrap_gcp.sh "your-gcp-project-id" "your-org/your-repo"
+#
+# Optional environment variables (or script arguments in order after required ones):
+#   SERVICE_ACCOUNT_NAME (default: drydock-workflow-sa)
+#   WORKLOAD_IDENTITY_POOL_ID (default: drydock-pool)
+#   WORKLOAD_IDENTITY_PROVIDER_ID (default: github-provider)
+#   GCS_CARGO_BUCKET_NAME (default: drydock-cargo-${GCP_PROJECT_ID_LOWERCASE})
+#   GCP_REGION (default: US)
+
+set -euo pipefail
+
+usage() {
+  echo "Usage: $0 [GCP_PROJECT_ID] [GITHUB_ORG_REPO] [SERVICE_ACCOUNT_NAME] [WORKLOAD_IDENTITY_POOL_ID] [WORKLOAD_IDENTITY_PROVIDER_ID] [GCS_CARGO_BUCKET_NAME] [GCP_REGION]"
+  echo ""
+  echo "Arguments can also be set as environment variables (see script comments)."
+  echo "  -h, --help    Display this help message."
+  exit 0
+}
+
+if [[ "$1" == "-h" || "$1" == "--help" ]]; then
+  usage
+fi
+
+# --- User Inputs & Defaults ---
+GCP_PROJECT_ID="${GCP_PROJECT_ID:-${1:-}}"
+GITHUB_ORG_REPO="${GITHUB_ORG_REPO:-${2:-}}"
+
+SERVICE_ACCOUNT_NAME="${SERVICE_ACCOUNT_NAME:-${3:-drydock-workflow-sa}}"
+WORKLOAD_IDENTITY_POOL_ID="${WORKLOAD_IDENTITY_POOL_ID:-${4:-drydock-pool}}"
+WORKLOAD_IDENTITY_PROVIDER_ID="${WORKLOAD_IDENTITY_PROVIDER_ID:-${5:-github-provider}}"
+GCP_PROJECT_ID_LOWERCASE=$(echo "${GCP_PROJECT_ID}" | tr '[:upper:]' '[:lower:]')
+DEFAULT_BUCKET_NAME="drydock-cargo-${GCP_PROJECT_ID_LOWERCASE}"
+GCS_CARGO_BUCKET_NAME="${GCS_CARGO_BUCKET_NAME:-${6:-${DEFAULT_BUCKET_NAME}}}"
+GCP_REGION="${GCP_REGION:-${7:-US}}" # Multi-region for GCS bucket
+
+# Validate required inputs
+if [ -z "${GCP_PROJECT_ID}" ]; then
+  echo "Error: GCP_PROJECT_ID is not set. Please set it as an environment variable or pass as the first argument."
+  usage
+fi
+if [ -z "${GITHUB_ORG_REPO}" ]; then
+  echo "Error: GITHUB_ORG_REPO is not set (format: ORG/REPO_NAME). Please set it as an environment variable or pass as the second argument."
+  usage
+fi
+if ! [[ "${GITHUB_ORG_REPO}" =~ ^[a-zA-Z0-9_-]+/[a-zA-Z0-9_.-]+$ ]]; then
+    echo "Error: GITHUB_ORG_REPO format is invalid. Expected 'ORG/REPO_NAME'."
+    exit 1
+fi
+
+echo "--- Configuration ---"
+echo "GCP Project ID:                 ${GCP_PROJECT_ID}"
+echo "GitHub Org/Repo:                ${GITHUB_ORG_REPO}"
+echo "Service Account Name:           ${SERVICE_ACCOUNT_NAME}"
+echo "Workload Identity Pool ID:      ${WORKLOAD_IDENTITY_POOL_ID}"
+echo "Workload Identity Provider ID:  ${WORKLOAD_IDENTITY_PROVIDER_ID}"
+echo "GCS Cargo Bucket Name:          ${GCS_CARGO_BUCKET_NAME}"
+echo "GCS Bucket Region:              ${GCP_REGION}"
+echo "---------------------"
+
+read -p "Proceed with creating these resources? (y/N): " confirm
+if [[ "${confirm}" != "y" && "${confirm}" != "Y" ]]; then
+  echo "Aborted by user."
+  exit 0
+fi
+
+echo "Fetching Project Number for ${GCP_PROJECT_ID}..."
+GCP_PROJECT_NUMBER=$(gcloud projects describe "${GCP_PROJECT_ID}" --format='value(projectNumber)')
+if [ -z "${GCP_PROJECT_NUMBER}" ]; then
+    echo "Error: Failed to fetch project number for ${GCP_PROJECT_ID}. Please ensure the project exists and you have permissions."
+    exit 1
+fi
+echo "Project Number: ${GCP_PROJECT_NUMBER}"
+
+echo "--- Enabling APIs ---"
+gcloud services enable \
+  iam.googleapis.com \
+  iamcredentials.googleapis.com \
+  storage.googleapis.com \
+  secretmanager.googleapis.com \
+  --project="${GCP_PROJECT_ID}"
+echo "APIs enabled."
+
+SA_EMAIL="${SERVICE_ACCOUNT_NAME}@${GCP_PROJECT_ID}.iam.gserviceaccount.com"
+
+echo "--- Creating Service Account ---"
+if gcloud iam service-accounts describe "${SA_EMAIL}" --project="${GCP_PROJECT_ID}" > /dev/null 2>&1; then
+  echo "Service Account ${SA_EMAIL} already exists. Skipping creation."
+else
+  gcloud iam service-accounts create "${SERVICE_ACCOUNT_NAME}" \
+    --project="${GCP_PROJECT_ID}" \
+    --display-name="Drydock Workflow Service Account"
+  echo "Service Account ${SA_EMAIL} created."
+fi
+
+echo "--- Creating Workload Identity Pool ---"
+if gcloud iam workload-identity-pools describe "${WORKLOAD_IDENTITY_POOL_ID}" --project="${GCP_PROJECT_ID}" --location="global" > /dev/null 2>&1; then
+  echo "Workload Identity Pool ${WORKLOAD_IDENTITY_POOL_ID} already exists. Skipping creation."
+else
+  gcloud iam workload-identity-pools create "${WORKLOAD_IDENTITY_POOL_ID}" \
+    --project="${GCP_PROJECT_ID}" \
+    --location="global" \
+    --display-name="Drydock WIF Pool"
+  echo "Workload Identity Pool ${WORKLOAD_IDENTITY_POOL_ID} created."
+fi
+
+WIF_PROVIDER_FQN="projects/${GCP_PROJECT_NUMBER}/locations/global/workloadIdentityPools/${WORKLOAD_IDENTITY_POOL_ID}/providers/${WORKLOAD_IDENTITY_PROVIDER_ID}"
+ALLOWED_AUDIENCE="https://iam.googleapis.com/${WIF_PROVIDER_FQN}" # Audience can be the provider path itself
+
+echo "--- Creating Workload Identity Provider ---"
+if gcloud iam workload-identity-pools providers describe "${WORKLOAD_IDENTITY_PROVIDER_ID}" --project="${GCP_PROJECT_ID}" --workload-identity-pool="${WORKLOAD_IDENTITY_POOL_ID}" --location="global" > /dev/null 2>&1; then
+  echo "Workload Identity Provider ${WORKLOAD_IDENTITY_PROVIDER_ID} already exists. Skipping creation."
+else
+  gcloud iam workload-identity-pools providers create-oidc "${WORKLOAD_IDENTITY_PROVIDER_ID}" \
+    --project="${GCP_PROJECT_ID}" \
+    --workload-identity-pool="${WORKLOAD_IDENTITY_POOL_ID}" \
+    --location="global" \
+    --issuer-uri="https://token.actions.githubusercontent.com" \
+    --allowed-audiences="${ALLOWED_AUDIENCE}" \
+    --attribute-mapping="google.subject=assertion.sub,attribute.actor=assertion.actor,attribute.repository=assertion.repository" \
+    --display-name="GitHub Actions Provider for Drydock"
+  echo "Workload Identity Provider ${WORKLOAD_IDENTITY_PROVIDER_ID} created."
+fi
+
+echo "--- Setting IAM Policy for WIF (Service Account Impersonation) ---"
+# This command is additive, so running it multiple times for the same member/role is generally fine.
+# However, for true idempotency, one might check if the binding already exists, which is more complex.
+gcloud iam service-accounts add-iam-policy-binding "${SA_EMAIL}" \
+  --project="${GCP_PROJECT_ID}" \
+  --role="roles/iam.workloadIdentityUser" \
+  --member="principalSet://iam.googleapis.com/projects/${GCP_PROJECT_NUMBER}/locations/global/workloadIdentityPools/${WORKLOAD_IDENTITY_POOL_ID}/attribute.repository/${GITHUB_ORG_REPO}"
+echo "IAM policy binding for WIF set on Service Account ${SA_EMAIL}."
+
+
+echo "--- Creating GCS Bucket for Cargo ---"
+BUCKET_URI="gs://${GCS_CARGO_BUCKET_NAME}"
+if gsutil ls -b "${BUCKET_URI}" > /dev/null 2>&1; then
+  echo "GCS Bucket ${BUCKET_URI} already exists. Skipping creation."
+else
+  gsutil mb -p "${GCP_PROJECT_ID}" -l "${GCP_REGION}" "${BUCKET_URI}"
+  echo "GCS Bucket ${BUCKET_URI} created."
+fi
+
+echo "--- Setting Uniform Bucket-Level Access ---"
+gsutil uniformbucketlevelaccess set on "${BUCKET_URI}"
+echo "Uniform bucket-level access set on ${BUCKET_URI}."
+
+echo "--- Setting IAM Policy for GCS Bucket Access ---"
+# gsutil iam ch is idempotent in effect.
+gsutil iam ch "serviceAccount:${SA_EMAIL}:objectAdmin" "${BUCKET_URI}"
+echo "IAM policy for SA ${SA_EMAIL} to be objectAdmin on ${BUCKET_URI} set."
+
+echo "--- Setting IAM Policy for Secret Manager Access ---"
+# This command is additive.
+gcloud projects add-iam-policy-binding "${GCP_PROJECT_ID}" \
+  --member="serviceAccount:${SA_EMAIL}" \
+  --role="roles/secretmanager.secretAccessor"
+echo "IAM policy for SA ${SA_EMAIL} to be secretmanager.secretAccessor on project ${GCP_PROJECT_ID} set."
+
+echo "--- Bootstrap Complete! ---"
+echo ""
+echo "--- GitHub Secret Values ---"
+echo "Copy these values into your GitHub repository secrets (Settings -> Secrets and variables -> Actions):"
+echo ""
+echo "GCP_WORKLOAD_IDENTITY_PROVIDER: ${WIF_PROVIDER_FQN}"
+echo "GCP_SERVICE_ACCOUNT_EMAIL:      ${SA_EMAIL}"
+echo "GCP_CARGO_BUCKET:               ${GCS_CARGO_BUCKET_NAME}"
+echo "GCP_PROJECT_ID:                 ${GCP_PROJECT_ID}" # (This is the Project ID you provided)
+echo ""
+echo "--- Important Next Steps ---"
+echo "1. Populate your GCS cargo bucket ('${GCS_CARGO_BUCKET_NAME}') with environment-specific .tfvars and .override.yaml files."
+echo "   Refer to USAGE.md for naming conventions (e.g., terraform/dev.tfvars, helm/dev.override.yaml)."
+echo "2. Populate GCP Secret Manager with secrets named 'tf-secrets.auto.tfvars' and 'helm-secrets.yaml' if you plan to use this feature."
+echo "   Refer to USAGE.md for content format."
+echo "3. Ensure the GitHub repository '${GITHUB_ORG_REPO}' has granted access to this Workload Identity Provider if necessary (org/repo settings)."
+echo ""
+echo "To make this script executable: chmod +x scripts/bootstrap/bootstrap_gcp.sh"
+
+exit 0


### PR DESCRIPTION
Introduces scripts and documentation to automate the initial setup of required cloud provider resources for Drydock on GCP and Azure.

Key additions:
- **GCP Bootstrapping Script (`scripts/bootstrap/bootstrap_gcp.sh`):**
    - Automates creation of GCP Workload Identity Pool/Provider, Service Account, IAM bindings for WIF, GCS cargo bucket, and Secret Manager access for the SA.
    - Outputs values needed for GitHub Secrets.
- **Azure Bootstrapping Script (`scripts/bootstrap/bootstrap_azure.sh`):**
    - Automates creation of Azure AD App Registration with Federated Identity Credential, Service Principal, Role Assignments (Blob Storage, Key Vault, AKS), Storage Account, Blob Container, and Key Vault.
    - Outputs values needed for GitHub Secrets.
- **Bootstrapping Guide (`BOOTSTRAPPING.md`):**
    - Provides detailed instructions on prerequisites and usage for both bootstrapping scripts.
    - Explains how to configure GitHub Secrets with the script outputs.
- **Documentation Links:**
    - Updated `README.md` with a new "Getting Started" section linking to the bootstrapping guide.
    - Updated `USAGE.md` to direct you to the bootstrapping guide before manual configuration.

These additions aim to simplify the initial setup of Drydock and lower the barrier to entry for new users.